### PR TITLE
Fix comment typo in segnet decoder

### DIFF
--- a/nets/segnet_simple_lift_fuse_ablation_new_decoders.py
+++ b/nets/segnet_simple_lift_fuse_ablation_new_decoders.py
@@ -606,7 +606,7 @@ class SegnetSimpleLiftFuse(nn.Module):
         if self.use_multi_scale_img_feats:
 
             if self.encoder_type == 'dino_v2':
-                # we need to get the feature space down to 128 ---> do we loose too much information?
+                # we need to get the feature space down to 128 ---> do we lose too much information?
                 # use convolutions for that
                 img_encoder_feats, dino_out = self.encoder(rgb_camXs_)
                 if self.compress_adapter_output:


### PR DESCRIPTION
## Summary
- fix a spelling issue in `segnet_simple_lift_fuse_ablation_new_decoders.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445d9093b88322bfcb7aa816a57861