### PR TITLE
Fix backprop comments

### DIFF
--- a/nets/segnet_simple_bev_with_map.py
+++ b/nets/segnet_simple_bev_with_map.py
@@ -226,7 +226,7 @@ class DinoMulti2SingleScale(nn.Module):
         self.single_scale_compress = nn.Sequential(
             nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
             nn.InstanceNorm2d(out_channels),
-            nn.GELU(),  # ReLU throws backprob. error maybe due to "dying ReLU" problem !!!
+            nn.GELU(),  # ReLU throws backprop error maybe due to 'dying ReLU' problem
             nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1, bias=False),
             nn.InstanceNorm2d(out_channels),
             nn.GELU(),

--- a/nets/segnet_simple_lift_fuse_ablation_new_decoders.py
+++ b/nets/segnet_simple_lift_fuse_ablation_new_decoders.py
@@ -360,7 +360,7 @@ class DinoMulti2SingleScale(nn.Module):
         self.single_scale_compress = nn.Sequential(
             nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
             nn.InstanceNorm2d(out_channels),
-            nn.GELU(),  # ReLU throws backprob. error maybe due to "dying ReLU" problem !!!
+            nn.GELU(),  # ReLU throws backprop error maybe due to 'dying ReLU' problem
             nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1, bias=False),
             nn.InstanceNorm2d(out_channels),
             nn.GELU(),


### PR DESCRIPTION
## Summary
- correct `backprob` typo in GELU comments
- clarify comment about ReLU backprop error

## Testing
- `python -m py_compile nets/segnet_simple_bev_with_map.py nets/segnet_simple_lift_fuse_ablation_new_decoders.py`

------
https://chatgpt.com/codex/tasks/task_e_68445de95cfc8322a471379a02f270a8