### PR TITLE
Add lidar_nsweeps argument

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -650,6 +650,7 @@ def main(
         final_dim=[448, 896],  # to match //8, //14, //16 and //32 in Vit
         ncams=6,
         nsweeps=5,
+        lidar_nsweeps=5,
         # model
         encoder_type='dino_v2',
         radar_encoder_type='voxel_net',
@@ -722,7 +723,7 @@ def main(
         use_obj_layer_only_on_map=use_obj_layer_only_on_map,
         use_radar_occupancy_map=use_radar_occupancy_map,
         use_lidar=use_lidar,
-        lidar_nsweeps=nsweeps,
+        lidar_nsweeps=lidar_nsweeps,
         do_drn_val_split=do_drn_val_split,
         get_val_day=False,  # set 'True' for debug only
         get_val_rain=False,  # set 'True' for debug only

--- a/train.py
+++ b/train.py
@@ -921,6 +921,7 @@ def main(
         rand_crop_and_resize=True,
         ncams=6,
         nsweeps=5,
+        lidar_nsweeps=5,
         # model
         encoder_type='dino_v2',
         radar_encoder_type='voxel_net',
@@ -1027,6 +1028,7 @@ def main(
         "rand_crop_and_resize": rand_crop_and_resize,
         "ncams": ncams,
         "nsweeps": nsweeps,
+        "lidar_nsweeps": lidar_nsweeps,
         # model
         "encoder_type": encoder_type,
         "radar_encoder_type": radar_encoder_type,
@@ -1090,7 +1092,7 @@ def main(
         use_obj_layer_only_on_map=use_obj_layer_only_on_map,
         use_radar_occupancy_map=use_radar_occupancy_map,
         use_lidar=use_lidar,
-        lidar_nsweeps=nsweeps,
+        lidar_nsweeps=lidar_nsweeps,
     )
     train_iterloader = iter(train_dataloader)
 


### PR DESCRIPTION
## Summary
- extend main functions with `lidar_nsweeps`
- pass lidar sweep count to `compile_data`
- log lidar sweep count in wandb config

## Testing
- `python train.py --config='configs/train/train_bevcar_lidar.yaml'` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ecac7a0ac8322a91e1a058faab029