### PR TITLE
Add lidar_nsweeps argument

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,6 +1,8 @@
+# imports
 import argparse
 import os
 import random
+import inspect
 # os.environ['CUDA_VISIBLE_DEVICES'] = '0'
 # print("FIXED CUDA DEVICE: " + os.environ['CUDA_VISIBLE_DEVICES'])
 import time
@@ -368,6 +370,8 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, device='cuda:0', sw=None, use_
     seg_bev_g = seg_bev_g[:, 0]
     valid_bev_g = valid_bev_g[:, 0]
     radar_data = radar_data[:, 0]
+    if lidar_data is not None:
+        lidar_data = lidar_data[:, 0]
     # added bev_map_gt
     bev_map_mask_g = bev_map_mask_g[:, 0]
     if use_obj_layer_only_on_map:
@@ -465,13 +469,23 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, device='cuda:0', sw=None, use_
         lid_occ_mem0 = vox_util.voxelize_xyz(xyz_lid, Z, Y, X, assert_cube=False)
 
     start_inference_t = time.time()  # optional: pure inference timing
-    seg_e = model(
-        rgb_camXs=rgb_camXs,
-        pix_T_cams=pix_T_cams,
-        cam0_T_camXs=cam0_T_camXs,
-        vox_util=vox_util,
-        rad_occ_mem0=in_occ_mem0,
-        lidar_occ_mem0=lid_occ_mem0)
+    module = model.module if hasattr(model, "module") else model
+    forward_params = inspect.signature(module.forward).parameters
+    if "lidar_occ_mem0" in forward_params:
+        seg_e = model(
+            rgb_camXs=rgb_camXs,
+            pix_T_cams=pix_T_cams,
+            cam0_T_camXs=cam0_T_camXs,
+            vox_util=vox_util,
+            rad_occ_mem0=in_occ_mem0,
+            lidar_occ_mem0=lid_occ_mem0)
+    else:
+        seg_e = model(
+            rgb_camXs=rgb_camXs,
+            pix_T_cams=pix_T_cams,
+            cam0_T_camXs=cam0_T_camXs,
+            vox_util=vox_util,
+            rad_occ_mem0=in_occ_mem0)
     inference_t = time.time() - start_inference_t  # optional: pure inference timing
     # print("Inference time: ", inference_t)  # optional: pure inference timing
 
@@ -650,6 +664,7 @@ def main(
         final_dim=[448, 896],  # to match //8, //14, //16 and //32 in Vit
         ncams=6,
         nsweeps=5,
+        lidar_nsweeps=5,
         # model
         encoder_type='dino_v2',
         radar_encoder_type='voxel_net',
@@ -722,7 +737,7 @@ def main(
         use_obj_layer_only_on_map=use_obj_layer_only_on_map,
         use_radar_occupancy_map=use_radar_occupancy_map,
         use_lidar=use_lidar,
-        lidar_nsweeps=nsweeps,
+        lidar_nsweeps=lidar_nsweeps,
         do_drn_val_split=do_drn_val_split,
         get_val_day=False,  # set 'True' for debug only
         get_val_rain=False,  # set 'True' for debug only

--- a/train.py
+++ b/train.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import random
+import inspect
 # os.environ['CUDA_VISIBLE_DEVICES'] = '0'  # may help for debugging
 # print("FIXED CUDA DEVICE: " + os.environ['CUDA_VISIBLE_DEVICES'])  # debug-only
 import time
@@ -490,6 +491,8 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, device='cuda:0', sw=None, use_
     seg_bev_g = seg_bev_g[:, 0]
     valid_bev_g = valid_bev_g[:, 0]
     radar_data = radar_data[:, 0]
+    if lidar_data is not None:
+        lidar_data = lidar_data[:, 0]
     # added bev_map_gt
     bev_map_mask_g = bev_map_mask_g[:, 0]
     if use_obj_layer_only_on_map:
@@ -587,13 +590,23 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, device='cuda:0', sw=None, use_
     if use_lidar and xyz_lid is not None:
         lid_occ_mem0 = vox_util.voxelize_xyz(xyz_lid, Z, Y, X, assert_cube=False)
 
-    seg_e = model(
-        rgb_camXs=rgb_camXs,
-        pix_T_cams=pix_T_cams,
-        cam0_T_camXs=cam0_T_camXs,
-        vox_util=vox_util,
-        rad_occ_mem0=in_occ_mem0,
-        lidar_occ_mem0=lid_occ_mem0)
+    module = model.module if hasattr(model, "module") else model
+    forward_params = inspect.signature(module.forward).parameters
+    if "lidar_occ_mem0" in forward_params:
+        seg_e = model(
+            rgb_camXs=rgb_camXs,
+            pix_T_cams=pix_T_cams,
+            cam0_T_camXs=cam0_T_camXs,
+            vox_util=vox_util,
+            rad_occ_mem0=in_occ_mem0,
+            lidar_occ_mem0=lid_occ_mem0)
+    else:
+        seg_e = model(
+            rgb_camXs=rgb_camXs,
+            pix_T_cams=pix_T_cams,
+            cam0_T_camXs=cam0_T_camXs,
+            vox_util=vox_util,
+            rad_occ_mem0=in_occ_mem0)
 
     # get bev map from masks
     if train_task == 'both' or train_task == 'map':
@@ -921,6 +934,7 @@ def main(
         rand_crop_and_resize=True,
         ncams=6,
         nsweeps=5,
+        lidar_nsweeps=5,
         # model
         encoder_type='dino_v2',
         radar_encoder_type='voxel_net',
@@ -1027,6 +1041,7 @@ def main(
         "rand_crop_and_resize": rand_crop_and_resize,
         "ncams": ncams,
         "nsweeps": nsweeps,
+        "lidar_nsweeps": lidar_nsweeps,
         # model
         "encoder_type": encoder_type,
         "radar_encoder_type": radar_encoder_type,
@@ -1090,7 +1105,7 @@ def main(
         use_obj_layer_only_on_map=use_obj_layer_only_on_map,
         use_radar_occupancy_map=use_radar_occupancy_map,
         use_lidar=use_lidar,
-        lidar_nsweeps=nsweeps,
+        lidar_nsweeps=lidar_nsweeps,
     )
     train_iterloader = iter(train_dataloader)
 


### PR DESCRIPTION
## Summary
- extend main functions with `lidar_nsweeps`
- pass lidar sweep count to `compile_data`
- log lidar sweep count in wandb config
- slice lidar tensors along the time dimension before permutation
- handle models that don't accept lidar tensors

## Testing
- `pytest -q` *(no tests discovered)*
- `python train.py --config='configs/train/train_bevcar_lidar.yaml'` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ecac7a0ac8322a91e1a058faab029