### PR TITLE
Ensure constant LiDAR point count and add BEV visualization

### DIFF
--- a/nuscenes_data.py
+++ b/nuscenes_data.py
@@ -1114,6 +1114,16 @@ class VizData(NuscData):
         radar_data = np.transpose(radar_data)
         radar_data = torch.from_numpy(radar_data).float()
 
+        if lidar_data is not None:
+            lidar_data = np.transpose(lidar_data)
+            V_lid = 50000 * self.lidar_nsweeps
+            if lidar_data.shape[0] > V_lid:
+                lidar_data = lidar_data[:V_lid]
+            elif lidar_data.shape[0] < V_lid:
+                lidar_data = np.pad(lidar_data, [(0, V_lid - lidar_data.shape[0]), (0, 0)], mode='constant')
+            lidar_data = np.transpose(lidar_data)
+            lidar_data = torch.from_numpy(lidar_data).float()
+
         binimg = (binimg > 0).float()
         seg_bev = (seg_bev > 0).float()
 

--- a/tests/test_bev_visualization.py
+++ b/tests/test_bev_visualization.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def visualize_bev(map_mask, radar_pts, lidar_pts, out_path):
+    fig, ax = plt.subplots(figsize=(4, 4))
+    ax.imshow(map_mask, extent=[-50, 50, -50, 50], origin='lower', cmap='gray')
+    ax.scatter(radar_pts[:, 0], radar_pts[:, 1], c='r', s=8, label='Radar')
+    ax.scatter(lidar_pts[:, 0], lidar_pts[:, 1], c='b', s=2, label='LiDAR')
+    ax.set_xlim(-50, 50)
+    ax.set_ylim(-50, 50)
+    ax.set_xlabel('X')
+    ax.set_ylabel('Z')
+    ax.legend(loc='upper right')
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+def test_bev_visualization(tmp_path):
+    map_mask = np.zeros((200, 200))
+    map_mask[80:120, 80:120] = 1.0
+    radar_pts = np.random.uniform(-50, 50, size=(32, 2))
+    lidar_pts = np.random.uniform(-50, 50, size=(128, 2))
+    out_file = tmp_path / 'bev_overlay.png'
+    path = visualize_bev(map_mask, radar_pts, lidar_pts, str(out_file))
+    assert os.path.exists(path)


### PR DESCRIPTION
## Summary
- Pad and clip LiDAR data like radar to guarantee fixed point count and proper tensor layout
- Add basic BEV visualization test overlaying map, radar and LiDAR points

## Testing
- `pytest tests/test_bev_visualization.py::test_bev_visualization -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c6c06ac0948322bf015fd33c82f713