### PR TITLE
Add LiDAR support to DDP training script

### DIFF
--- a/configs/slurm/Train_DDP_H100_8nodes.slurm
+++ b/configs/slurm/Train_DDP_H100_8nodes.slurm
@@ -6,7 +6,7 @@
 #SBATCH --ntasks=96                   # 1 Task pro GPU
 #SBATCH --mem=1400G
 #SBATCH --output=logs_train/DDP_H100/%x_%j.out
-#SBATCH --job-name=bevcar_train
+#SBATCH --job-name=bev_clr_ad_train_ddp
 
 # Lade Module oder aktiviere Umgebung
 #source ~/.bashrc

--- a/configs/train/train_bev_clr_ad.yaml
+++ b/configs/train/train_bev_clr_ad.yaml
@@ -3,7 +3,7 @@ exp_name: 'BEV_CLR_AD'
 
 # Training parameters
 max_iters: 50000
-log_freq: 10
+log_freq: 100
 shuffle: true
 dset: 'trainval'
 save_freq: 1000
@@ -28,7 +28,7 @@ load_scheduler: true
 
 # Data parameters
 final_dim: [448, 896]  # to match //8, //14, //16 and //32 in Vit
-rand_flip: true
+rand_flip: false
 rand_crop_and_resize: true
 ncams: 6
 nsweeps: 5


### PR DESCRIPTION
## Summary
- switch DDP training to LiDAR-enabled SegnetTransformer and import inspect for runtime checks
- parse and voxelize LiDAR data in `run_model`, passing `lidar_occ_mem0` to models that accept it
- expose LiDAR configuration in `main`, propagate options to data loader and logging

## Testing
- `python -m py_compile train_DDP.py`
- `pytest -q` *(fails: No module named 'numpy'; dependency not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cdf430588322a866cd692181c4b5