### PR TITLE
Optimize BEV map rendering to cut iteration time

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -576,9 +576,12 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
             bev_map_only_mask_g = bev_map_mask_g
 
         map_seg_threshold = 0.4
+        bev_map_probs = torch.sigmoid(bev_map_mask_e).detach()
         bev_map_e = nuscenes_data.get_rgba_map_from_mask2_on_batch(
-            torch.sigmoid(bev_map_mask_e).detach().cpu().numpy(),
-            threshold=map_seg_threshold, a=0.4).to(device)
+            bev_map_probs,
+            threshold=map_seg_threshold,
+            a=0.4,
+        )
 
         # combine ego car and bev_map_e
         ego_car_on_map_e = bev_map_e * (1 - egocar_bev) + ego_plane * egocar_bev  # check dims

--- a/train.py
+++ b/train.py
@@ -671,9 +671,12 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
             bev_map_only_mask_g = bev_map_mask_g
 
         map_seg_threshold = 0.4
+        bev_map_probs = torch.sigmoid(bev_map_mask_e).detach()
         bev_map_e = nuscenes_data.get_rgba_map_from_mask2_on_batch(
-            torch.sigmoid(bev_map_mask_e).detach().cpu().numpy(),
-            threshold=map_seg_threshold, a=0.4).to(device)
+            bev_map_probs,
+            threshold=map_seg_threshold,
+            a=0.4,
+        )
 
         # combine ego car and bev_map_e
         ego_car_on_map_e = bev_map_e * (1 - egocar_bev) + ego_plane * egocar_bev  # check dims

--- a/train_DDP.py
+++ b/train_DDP.py
@@ -709,9 +709,12 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device, sw=None,
             bev_map_only_mask_g = bev_map_mask_g
 
         map_seg_threshold = 0.4
+        bev_map_probs = torch.sigmoid(bev_map_mask_e).detach()
         bev_map_e = nuscenes_data.get_rgba_map_from_mask2_on_batch(
-            torch.sigmoid(bev_map_mask_e).detach().cpu().numpy(),
-            threshold=map_seg_threshold, a=0.4).to(device)
+            bev_map_probs,
+            threshold=map_seg_threshold,
+            a=0.4,
+        )
 
         # combine ego car and bev_map_e
         ego_car_on_map_e = bev_map_e * (1 - egocar_bev) + ego_plane * egocar_bev

--- a/vis_eval.py
+++ b/vis_eval.py
@@ -526,9 +526,12 @@ def run_model(loader, index, model, loss_fn, map_seg_loss_fn, d, img_dir, device
                 bev_map_only_mask_g = bev_map_mask_g
 
             map_seg_threshold = 0.4
+            bev_map_probs = torch.sigmoid(bev_map_mask_e).detach()
             bev_map_e = nuscenes_data.get_rgba_map_from_mask2_on_batch(
-                torch.sigmoid(bev_map_mask_e).detach().cpu().numpy(),
-                threshold=map_seg_threshold, a=1.0).to(device)  # a=0.4
+                bev_map_probs,
+                threshold=map_seg_threshold,
+                a=1.0,
+            )  # a=0.4
 
             # combine ego car and bev_map_e
             ego_car_on_map_e = bev_map_e * (1 - egocar_bev) + ego_plane * egocar_bev  # check dims


### PR DESCRIPTION
## Summary
- avoid repeatedly converting BEV map logits to NumPy during training and evaluation
- render BEV map overlays directly on the tensor device to reduce per-iteration overhead

## Testing
- python -m compileall nuscenes_data.py train.py train_DDP.py eval.py vis_eval.py

------
https://chatgpt.com/codex/tasks/task_e_68fa5649155c83229c5e802698a70a65