### PR TITLE
Enable float16 dataloading option for training workflows

### DIFF
--- a/configs/eval/eval_bev_clr_ad.yaml
+++ b/configs/eval/eval_bev_clr_ad.yaml
@@ -34,6 +34,7 @@ ncams: 6                         # Number of cameras per sample (nuScenes uses 6
 nsweeps: 5                       # Number of RADAR sweeps aggregated per sample.
 lidar_nsweeps: 1                 # Number of LiDAR sweeps aggregated per sample (matches training pipeline).
 grid_dim: [200, 8, 200]          # Voxel grid (Z, Y, X). Y is vertical bins; BEV plane is Z (forward) × X (right).
+half_precision_data: false       # Cast heavy BEV targets/masks/point clouds to float16 during eval or debug runs.
 
 # ======================
 # Model parameters

--- a/configs/train/train_bev_clr_ad.yaml
+++ b/configs/train/train_bev_clr_ad.yaml
@@ -44,6 +44,7 @@ ncams: 6                         # Number of cameras per sample (nuScenes uses 6
 nsweeps: 5                       # Number of RADAR sweeps to aggregate per sample (passed to the loader).
 lidar_nsweeps: 1                 # Number of LiDAR sweeps to aggregate per sample (used when use_lidar=true).
 grid_dim: [400, 8, 400]          # Voxel grid (Z, Y, X). Y is vertical bins; BEV plane is Z (forward) × X (right).
+half_precision_data: false       # If true, cast heavy BEV targets/masks/point clouds to float16 for training & val.
 
 # ======================
 # Core task selection

--- a/configs/vis/vis_bevcar.yaml
+++ b/configs/vis/vis_bevcar.yaml
@@ -23,6 +23,7 @@ load_step: 50000
 final_dim: [448, 896]  # to match //8, //14, //16 and //32 in Vit
 ncams: 6
 nsweeps: 5
+half_precision_data: false  # Optional float16 casting for memory-friendly visualization runs.
 
 # Model parameters
 encoder_type: 'dino_v2'

--- a/eval.py
+++ b/eval.py
@@ -768,6 +768,7 @@ def main(
         use_radar_occupancy_map=False,  # occupancy_radar_rpn
         do_drn_val_split=True,  # True
         learnable_fuse_query=True,
+        half_precision_data=False,
 ):
     print("### FINAL EVAL KWARGS ###")
     bound = inspect.signature(main).bind_partial(**locals())
@@ -828,7 +829,8 @@ def main(
         do_drn_val_split=do_drn_val_split,
         get_val_day=False,  # set 'True' for debug only
         get_val_rain=False,  # set 'True' for debug only
-        get_val_night=False  # set 'True' for debug only
+        get_val_night=False,  # set 'True' for debug only
+        half_precision_data=half_precision_data
     )
     val_iterloader = iter(val_dataloader)
 

--- a/train.py
+++ b/train.py
@@ -1035,6 +1035,7 @@ def main(
         use_lidar=True,
         use_lidar_encoder=True,
         use_lidar_occupancy_map=False,
+        half_precision_data=False,
         use_pre_scaled_imgs=False,
         use_obj_layer_only_on_map=False,
         init_query_with_image_feats=True,
@@ -1206,6 +1207,7 @@ def main(
         use_radar_occupancy_map=use_radar_occupancy_map,
         use_lidar=use_lidar,
         lidar_nsweeps=lidar_nsweeps,
+        half_precision_data=half_precision_data,
     )
     train_iterloader = iter(train_dataloader)
 

--- a/vis_eval.py
+++ b/vis_eval.py
@@ -830,6 +830,7 @@ def main(
         freeze_dino=True,
         do_feat_enc_dec=True,
         learnable_fuse_query=True,
+        half_precision_data=False,
 ):
     assert (model_type in ['transformer', 'simple_lift_fuse', 'SimpleBEV_map'])
     B = batch_size
@@ -879,7 +880,8 @@ def main(
         custom_dataroot=custom_dataroot,
         use_obj_layer_only_on_map=use_obj_layer_only_on_map,
         vis_full_scenes=vis_full_scenes,
-        do_drn_val_split=do_drn_val_split
+        do_drn_val_split=do_drn_val_split,
+        half_precision_data=half_precision_data
     )
 
     iterloader = iter(dataloader)


### PR DESCRIPTION
## Summary
- allow the nuScenes dataset loader to cast dense BEV targets and sensor tensors to float16 whenever `half_precision_data` is enabled
- thread the new toggle through the training, evaluation, and visualization entry points and surface it in their configs for easy activation

## Testing
- python -m compileall nuscenes_data.py train.py eval.py vis_eval.py

------
https://chatgpt.com/codex/tasks/task_e_68fcbcfe64048322a486e027a54b0b3c