### PR TITLE
Fix LiDAR-disabled batching path

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -364,8 +364,10 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
     seg_bev_g = seg_bev_g[:, 0]
     valid_bev_g = valid_bev_g[:, 0]
     radar_data = radar_data[:, 0]
-    if lidar_data is not None:
+    if use_lidar and lidar_data is not None:
         lidar_data = lidar_data[:, 0]
+    else:
+        lidar_data = None
     # added bev_map_gt
     bev_map_mask_g = bev_map_mask_g[:, 0]
     if use_obj_layer_only_on_map:

--- a/nuscenes_data.py
+++ b/nuscenes_data.py
@@ -1232,7 +1232,8 @@ class VizData(NuscData):
             all_seg_bev.append(seg_bev)
             all_valid_bev.append(valid_bev)
             all_radar_data.append(radar_data)
-            all_lidar_data.append(lidar_data)
+            if self.use_lidar:
+                all_lidar_data.append(lidar_data)
             # added bev_map_gt
             all_bev_map_mask.append(bev_map_mask)
             all_bev_map.append(bev_map)
@@ -1246,7 +1247,12 @@ class VizData(NuscData):
         all_seg_bev = torch.stack(all_seg_bev)
         all_valid_bev = torch.stack(all_valid_bev)
         all_radar_data = torch.stack(all_radar_data)
-        all_lidar_data = torch.stack(all_lidar_data)
+
+        if self.use_lidar:
+            all_lidar_data = torch.stack(all_lidar_data)
+        else:
+            # placeholder tensor so the default collate_fn can batch samples without LiDAR
+            all_lidar_data = torch.zeros(1, dtype=torch.float32)
         # added bev_map_gt
         all_bev_map_mask = torch.stack(all_bev_map_mask)
         all_bev_map = torch.stack(all_bev_map)

--- a/train.py
+++ b/train.py
@@ -485,8 +485,10 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
     seg_bev_g = seg_bev_g[:, 0]
     valid_bev_g = valid_bev_g[:, 0]
     radar_data = radar_data[:, 0]
-    if lidar_data is not None:
+    if use_lidar and lidar_data is not None:
         lidar_data = lidar_data[:, 0]
+    else:
+        lidar_data = None
     # added bev_map_gt
     bev_map_mask_g = bev_map_mask_g[:, 0]
     if use_obj_layer_only_on_map:

--- a/train_DDP.py
+++ b/train_DDP.py
@@ -524,8 +524,10 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device, sw=None,
     seg_bev_g = seg_bev_g[:, 0]
     valid_bev_g = valid_bev_g[:, 0]
     radar_data = radar_data[:, 0]
-    if lidar_data is not None:
+    if use_lidar and lidar_data is not None:
         lidar_data = lidar_data[:, 0]
+    else:
+        lidar_data = None
     # added bev_map_gt
     bev_map_mask_g = bev_map_mask_g[:, 0]
     if use_obj_layer_only_on_map:


### PR DESCRIPTION
## Summary
- only collect LiDAR tensors when the modality is enabled and return a collate-friendly placeholder otherwise
- have the training and evaluation loops drop the placeholder so downstream code still receives `None`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffc668e8348322ab651402d00e2437