### PR TITLE
Preserve wandb runs when resuming from checkpoints

### DIFF
--- a/train_DDP.py
+++ b/train_DDP.py
@@ -1214,8 +1214,20 @@ def main(
         "combine_feat_init_w_learned_q": combine_feat_init_w_learned_q,
     }
 
+    wandb_resume_kwargs = {}
+    if init_dir and load_step:
+        resume_step = 0
+        if not isinstance(load_step, bool) and isinstance(load_step, int):
+            resume_step = load_step
+        previous_run_id = saverloader.get_wandb_run_id(init_dir, step=resume_step)
+        if previous_run_id is not None and is_master:
+            print(f"Resuming wandb run with id {previous_run_id}")
+        if previous_run_id is not None:
+            wandb_resume_kwargs = {'id': previous_run_id, 'resume': 'must'}
+
     if is_master:
-        wandb.init(project=model_name, config=wandb_config, group=group, notes=notes, name=name)
+        wandb.init(project=model_name, config=wandb_config, group=group, notes=notes, name=name,
+                   **wandb_resume_kwargs)
     # no barrier here
 
     if rand_crop_and_resize:
@@ -1440,7 +1452,7 @@ def main(
         if np.mod(global_step, save_freq) == 0:
             if rank == 0:
                 saverloader.save(ckpt_dir, optimizer, model.module, global_step, scheduler=scheduler,
-                             keep_latest=keep_latest)
+                                 keep_latest=keep_latest, wandb_run_id=getattr(wandb.run, 'id', None))
             # wait until model is saved
             dist.barrier()
 


### PR DESCRIPTION
## Summary
- store the associated Weights & Biases run id inside saved checkpoints
- reuse an existing run id when loading checkpoints so resumed training continues logging to the same run
- pass the active run id back into checkpoint saves in both single-GPU and DDP trainers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908ce70ddb483229ea8a6cc8d64726b