### PR TITLE
Add VoxelNeXt LiDAR encoder option

### DIFF
--- a/configs/eval/eval_bev_clr_ad.yaml
+++ b/configs/eval/eval_bev_clr_ad.yaml
@@ -40,7 +40,7 @@ grid_dim: [400, 8, 400]          # Voxel grid (Z, Y, X). Y is vertical bins; BEV
 # ======================
 encoder_type: 'dino_v2'          # Image backbone: 'dino_v2' (ViT-B/14 adapter).
 radar_encoder_type: 'voxel_net'  # RADAR BEV encoder: currently 'voxel_net' (sparse voxel feature net).
-lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder: currently 'voxel_net' (sparse voxel feature net).
+lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder: 'voxel_net' (dense) or 'voxel_next' (sparse spconv backbone).
 use_rpn_radar: false             # Keep RPN disabled as in training.
 train_task: 'both'               # Shared decoder for objects and semantic map tasks.
 use_radar: true                  # Enable RADAR branch during inference.

--- a/configs/eval/eval_bev_clr_ad.yaml
+++ b/configs/eval/eval_bev_clr_ad.yaml
@@ -21,10 +21,10 @@ data_dir: '/../../../../../../beegfs/scratch/workspace/es_luheit04-NuScneDataset
 custom_dataroot: 'datasets/scaled_images'
                                  # Optional pre-scaled images root used when use_pre_scaled_imgs=true.
 log_dir: 'logs_eval'             # TensorBoard/TensorboardX evaluation log root.
-init_dir: 'model_checkpoints/BEV_CLR_AD_1x5x8_3e-4s_13-29-17'
+init_dir: 'model_checkpoints/BEV_CLR_AD_1x5x8_3e-4s_14-45-27'
                                  # Directory containing the checkpoint to evaluate.
 ignore_load: null                # Optional list/pattern of keys to ignore when loading the checkpoint.
-load_step: 35000                 # Specific training step checkpoint to load (set to null to load latest).
+load_step: 50000                 # Specific training step checkpoint to load (set to null to load latest).
 
 # ======================
 # Data parameters

--- a/configs/train/train_bev_clr_ad_H100.yaml
+++ b/configs/train/train_bev_clr_ad_H100.yaml
@@ -78,7 +78,7 @@ use_shallow_metadata: true       # Enable 4-ch lightweight radar meta features (
 # ======================
 # LiDAR branch
 # ======================
-lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder type when use_lidar_encoder=true.
+lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder type when use_lidar_encoder=true ('voxel_net' or 'voxel_next').
 use_lidar: true                  # Toggle LiDAR branch. (Your current data pipeline expects LiDAR present.)
 use_lidar_encoder: true          # If false, use the lightweight “occupancy compressor” (Option A) we added.
 use_lidar_occupancy_map: false   # If true (and encoder supports), provide a 1-ch LiDAR occupancy map to the encoder.

--- a/configs/train/train_bev_clr_ad_L40S.yaml
+++ b/configs/train/train_bev_clr_ad_L40S.yaml
@@ -6,7 +6,7 @@ exp_name: 'BEV_CLR_AD'           # Used to build run names, checkpoint/log folde
 # ======================
 # Training parameters
 # ======================
-max_iters: 100000                 # Total optimization steps (NOT epochs). Effective data seen depends on dataloader size.
+max_iters: 70000                 # Total optimization steps (NOT epochs). Effective data seen depends on dataloader size.
 log_freq: 100                    # How often to log scalars/images to TensorBoard/W&B (in steps).
 shuffle: true                    # Shuffle training samples each epoch (affects dataloader).
 dset: 'trainval'                 # Dataset split to load in nuscenes_data.compile_data (e.g., 'train', 'trainval', 'mini').
@@ -78,7 +78,7 @@ use_shallow_metadata: true       # Enable 4-ch lightweight radar meta features (
 # ======================
 # LiDAR branch
 # ======================
-lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder type when use_lidar_encoder=true ('voxel_net' or 'voxel_next').
+lidar_encoder_type: 'voxel_next'  # LiDAR BEV encoder type when use_lidar_encoder=true ('voxel_net' or 'voxel_next').
 use_lidar: true                  # Toggle LiDAR branch. (Your current data pipeline expects LiDAR present.)
 use_lidar_encoder: true          # If false, use the lightweight “occupancy compressor”
 use_lidar_occupancy_map: false   # If true (and encoder supports), provide a 1-ch LiDAR occupancy map to the encoder.

--- a/configs/train/train_bev_clr_ad_L40S.yaml
+++ b/configs/train/train_bev_clr_ad_L40S.yaml
@@ -78,7 +78,7 @@ use_shallow_metadata: true       # Enable 4-ch lightweight radar meta features (
 # ======================
 # LiDAR branch
 # ======================
-lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder type when use_lidar_encoder=true.
+lidar_encoder_type: 'voxel_net'  # LiDAR BEV encoder type when use_lidar_encoder=true ('voxel_net' or 'voxel_next').
 use_lidar: true                  # Toggle LiDAR branch. (Your current data pipeline expects LiDAR present.)
 use_lidar_encoder: true          # If false, use the lightweight “occupancy compressor”
 use_lidar_occupancy_map: false   # If true (and encoder supports), provide a 1-ch LiDAR occupancy map to the encoder.

--- a/nets/segnet_transformer_lift_fuse_lidar.py
+++ b/nets/segnet_transformer_lift_fuse_lidar.py
@@ -19,6 +19,7 @@ from nets.dino_v2_with_adapter.dino_v2_adapter.dinov2_adapter import (
 )
 from nets.ops.modules import MSDeformAttn, MSDeformAttn3D
 from nets.voxelnet import VoxelNet
+from nets.voxelNeXt import VoxelResBackBone8xVoxelNeXt
 
 torch.autograd.set_detect_anomaly(False) # just for debugging purposes
 
@@ -700,7 +701,7 @@ class SegnetTransformerLiftFuse(nn.Module):
         super(SegnetTransformerLiftFuse, self).__init__()
         assert (encoder_type in ["res101", "res50", "dino_v2", "vit_s"])
         assert (radar_encoder_type in ["voxel_net", None])
-        assert (lidar_encoder_type in ["voxel_net", None])
+        assert (lidar_encoder_type in ["voxel_net", "voxel_next", None])
         assert (train_task in ["object", "map", "both"])
 
         self.Z_cam, self.Y_cam, self.X_cam = Z_cam, Y_cam, X_cam  # Z=200, Y=8, X=200
@@ -833,6 +834,14 @@ class SegnetTransformerLiftFuse(nn.Module):
                     use_radar_occupancy_map=self.use_lidar_occupancy_map,
                     Z=self.Z_rad, Y=self.Y_rad, X=self.X_rad,  # keep as you had it
                     point_feature_dim=4,
+                )
+            elif self.lidar_encoder_type == "voxel_next":
+                voxelnext_cfg = {"OUT_CHANNEL": latent_dim}
+                grid_size = np.array([self.Z_rad, self.Y_rad, self.X_rad], dtype=int)
+                self.lidar_encoder = VoxelResBackBone8xVoxelNeXt(
+                    model_cfg=voxelnext_cfg,
+                    input_channels=7,
+                    grid_size=grid_size,
                 )
             else:
                 print("LiDAR encoder not found ")
@@ -974,6 +983,52 @@ class SegnetTransformerLiftFuse(nn.Module):
                                              assert_cube=False)  # transforms mem coordinates into ref coordinates
         else:
             self.xyz_camA = None
+
+    def _voxelnet_tuple_to_spconv_inputs(
+        self,
+        voxel_features: torch.Tensor,
+        voxel_coords: torch.Tensor,
+        num_voxels: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Prepare VoxelNet-style tensors for the VoxelNeXt sparse backbone.
+
+        Args:
+            voxel_features: Tensor shaped (B, K, T, C) with per-point features.
+            voxel_coords: Tensor shaped (B, K, 3) containing integer (z, y, x) coords.
+            num_voxels: Tensor shaped (B,) indicating how many voxels are valid per batch.
+
+        Returns:
+            A tuple of (features, coords) where features has shape (N, C) and coords
+            has shape (N, 4) with leading batch indices, or (None, None) if empty.
+        """
+        B, _, max_points, feat_dim = voxel_features.shape
+        all_features = []
+        all_coords = []
+
+        for b in range(B):
+            valid = int(num_voxels[b].item())
+            if valid <= 0:
+                continue
+
+            feats_b = voxel_features[b, :valid]  # (K, T, C)
+            coords_b = voxel_coords[b, :valid].int()
+
+            point_mask = feats_b.abs().sum(dim=-1) > 0
+            point_counts = point_mask.sum(dim=1, keepdim=True).clamp(min=1)
+            voxel_means = (feats_b * point_mask.unsqueeze(-1)).sum(dim=1) / point_counts
+
+            batch_inds = torch.full((valid, 1), b, dtype=coords_b.dtype, device=coords_b.device)
+            coords_with_batch = torch.cat([batch_inds, coords_b], dim=1)
+
+            all_features.append(voxel_means.reshape(-1, feat_dim))
+            all_coords.append(coords_with_batch)
+
+        if not all_features:
+            return None, None
+
+        features = torch.cat(all_features, dim=0)
+        coords = torch.cat(all_coords, dim=0)
+        return features, coords
 
     def forward(self, rgb_camXs: torch.Tensor, pix_T_cams: torch.Tensor, cam0_T_camXs: torch.Tensor,
                 vox_util: torch.Tensor, rad_occ_mem0: torch.Tensor = None, lidar_occ_mem0: torch.Tensor = None) -> torch.Tensor:
@@ -1168,6 +1223,32 @@ class SegnetTransformerLiftFuse(nn.Module):
                         number_of_occupied_voxels=lidar_occ_mem0[2],
                         dinovoxel=dinovoxel,
                     )
+                elif self.lidar_encoder_type == 'voxel_next':
+                    voxel_features, voxel_coords = self._voxelnet_tuple_to_spconv_inputs(
+                        voxel_features=lidar_occ_mem0[0],
+                        voxel_coords=lidar_occ_mem0[1],
+                        num_voxels=lidar_occ_mem0[2],
+                    )
+                    if voxel_features is None or voxel_coords is None:
+                        lid_bev_ = torch.zeros((B, self.latent_dim, self.Z_rad, self.X_rad), device=device)
+                    else:
+                        batch_dict = {
+                            'voxel_features': voxel_features,
+                            'voxel_coords': voxel_coords,
+                            'batch_size': B,
+                        }
+                        voxelnext_out = self.lidar_encoder(batch_dict)
+                        bev_tensor = voxelnext_out['encoded_spconv_tensor'].dense()
+
+                        if bev_tensor.shape[2] == self.Z_rad and bev_tensor.shape[3] == self.X_rad:
+                            lid_bev_ = bev_tensor
+                        elif bev_tensor.shape[2] == self.X_rad and bev_tensor.shape[3] == self.Z_rad:
+                            lid_bev_ = bev_tensor.permute(0, 1, 3, 2)
+                        else:
+                            raise ValueError(
+                                f"Unexpected VoxelNeXt BEV shape {bev_tensor.shape}; "
+                                f"expected ({B}, C, {self.Z_rad}, {self.X_rad}) (or transposed)."
+                            )
                 else:
                     if self.is_master:
                         print('LiDAR encoder type not supported')
@@ -1429,7 +1510,7 @@ class SegnetTransformerLiftFuse(nn.Module):
             if rad_occ_mem0 is not None and not (self.radar_encoder_type == "voxel_net"):
                 rad_occ_mem0[self.bev_flip1_index] = torch.flip(rad_occ_mem0[self.bev_flip1_index], [-1])
                 rad_occ_mem0[self.bev_flip2_index] = torch.flip(rad_occ_mem0[self.bev_flip2_index], [-3])
-            if lidar_occ_mem0 is not None and not (self.lidar_encoder_type == "voxel_net"):
+            if lidar_occ_mem0 is not None and not (self.lidar_encoder_type in ["voxel_net", "voxel_next"]):
                 lidar_occ_mem0[self.bev_flip1_index] = torch.flip(lidar_occ_mem0[self.bev_flip1_index], [-1])
                 lidar_occ_mem0[self.bev_flip2_index] = torch.flip(lidar_occ_mem0[self.bev_flip2_index], [-3])
 

--- a/nets/voxelNeXt.py
+++ b/nets/voxelNeXt.py
@@ -13,13 +13,6 @@ and therefore requires the ``spconv`` Python package to be installed
 The forward method accepts a ``batch_dict`` containing ``voxel_features``,
 ``voxel_coords`` and ``batch_size`` and returns the same dictionary
 with an added key ``encoded_spconv_tensor`` holding the BEV feature map.
-
-Note: The original VoxelNeXt backbone fuses multiple resolution levels
-and expects additional configuration from the surrounding detection
-framework.  This implementation preserves the architecture but omits
-any lidar-radar fusion logic.  To use this backbone you will need
-``spconv`` installed with CUDA support and may need to adjust your
-training scripts to handle the sparse tensors.
 """
 
 from __future__ import annotations
@@ -107,10 +100,10 @@ def post_act_block(in_channels: int,
 
 
 class SparseBasicBlock(SparseModule):
-    """Two–layer residual block for sparse 3D convolutions.
+    """Two-layer residual block for sparse 3D convolutions.
 
     This block mirrors the basic residual building block used in the
-    VoxelNeXt backbone.  It consists of two 3×3×3 submanifold
+    VoxelNeXt backbone.  It consists of two 3x3x3 submanifold
     convolutions with BatchNorm and ReLU, plus a residual connection.
     """
 
@@ -164,7 +157,7 @@ class VoxelResBackBone8xVoxelNeXt(nn.Module):
     the VoxelNeXt paper: a sequence of six sparse convolutional blocks
     with residual connections, culminating in a 2D sparse convolution to
     produce the BEV representation.  Additional information such as
-    multi–scale features and strides is stored in the returned
+    multi-scale features and strides is stored in the returned
     ``batch_dict`` for potential downstream use.
     """
 
@@ -196,7 +189,7 @@ class VoxelResBackBone8xVoxelNeXt(nn.Module):
             nn.ReLU(),
         )
 
-        # define helper for building post–activation blocks
+        # define helper for building post-activation blocks
         block = post_act_block
 
         # residual blocks at different scales
@@ -247,7 +240,7 @@ class VoxelResBackBone8xVoxelNeXt(nn.Module):
 
         # BEV output convolution: convert from 3D sparse conv to 2D
         self.conv_out = SparseSequential(
-            # maps from conv4 channels to out_channel using a 3×3 kernel
+            # maps from conv4 channels to out_channel using a 3x3 kernel
             # after concatenating features from deeper layers in forward()
             SparseConv2d(channels[3], out_channel, 3, stride=1, padding=1, bias=False, indice_key='spconv_down2'),
             norm_fn(out_channel),
@@ -271,7 +264,7 @@ class VoxelResBackBone8xVoxelNeXt(nn.Module):
         }
 
     def bev_out(self, x_conv: SparseConvTensor) -> SparseConvTensor:
-        """Collapse the z–dimension of a sparse tensor to produce a BEV tensor.
+        """Collapse the z-dimension of a sparse tensor to produce a BEV tensor.
 
         This method aggregates features across the depth dimension and
         collapses the indices accordingly.  It follows the logic of the
@@ -332,7 +325,7 @@ class VoxelResBackBone8xVoxelNeXt(nn.Module):
         x_conv6 = self.conv6(x_conv5)
 
         # upsample conv5 and conv6 features to match conv4 resolution
-        # This is equivalent to concatenating multi–scale features as
+        # This is equivalent to concatenating multi-scale features as
         # performed in the official implementation.
         # scale conv5 indices: multiply spatial coordinates by 2
         x_conv5 = x_conv5

--- a/nets/voxelNeXt_decoder.py
+++ b/nets/voxelNeXt_decoder.py
@@ -1,0 +1,187 @@
+"""
+VoxelNeXt Decoder Module
+========================
+
+This module defines a simple decoder that can upsample the coarse Bird's-Eye-View
+(BEV) feature maps produced by a VoxelNeXt backbone to match a desired BEV
+resolution.  The decoder mirrors the spirit of the upsampling layers used in
+traditional VoxelNet implementations but remains flexible: the number of
+upsampling stages is inferred from the desired output BEVMap size and the assumed
+downsampling factor of the backbone.
+
+Example
+-------
+
+Given a VoxelNeXt backbone that produces features with spatial dimensions
+``(H_in, W_in)`` and a target BEV map of size ``(H_out, W_out)``, this
+decoder upsamples the input feature map using a sequence of transposed
+convolutions with stride 2 until the height and width match the target
+resolution.  A final 1x1 convolution projects the feature channels to the
+desired latent dimension.
+
+If the required upsampling ratio is not a power of two (e.g. the target size
+is not an integer multiple of the input size), the decoder falls back to
+bilinear interpolation to reach the exact resolution.
+
+Parameters
+----------
+in_channels : int
+    Number of channels in the input feature map (from the VoxelNeXt backbone).
+latent_dim : int
+    Number of channels in the output BEV map.  This should match the latent
+    dimension expected by the downstream network (e.g. 128).
+target_z : int
+    Desired spatial size along the first spatial dimension of the BEV map (Z
+    dimension in the segmentation pipeline).  Typical values are 200 or 400.
+target_x : int
+    Desired spatial size along the second spatial dimension of the BEV map (X
+    dimension).  Typical values are the same as ``target_z``.
+downsample_factor : int, optional
+    Downsampling factor of the VoxelNeXt backbone relative to the desired BEV
+    resolution.  The default of 8 corresponds to a backbone that outputs
+    1/8-resolution BEV features (e.g. 25x25 from a 200x200 grid).  Adjust this
+    value if your backbone uses a different downsampling rate.
+"""
+
+#improvment idears: maybe add skip connections, or spatial attention modules, residual blocks, normalization 
+
+import math
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class VoxelNeXtDecoder(nn.Module):
+    """Decoder that upsamples coarse VoxelNeXt BEV features to a dense BEV map.
+
+    The decoder computes the required number of upsampling stages based on
+    ``target_z``, ``target_x`` and ``downsample_factor``.  Each stage uses a
+    transposed convolution with stride 2 to double the spatial resolution.
+    A final 1x1 convolution projects the feature channels to ``latent_dim``.
+    If the output dimensions do not match exactly after the upsampling stages
+    (e.g. because the desired resolution is not a power-of-two multiple of the
+    input), the decoder performs a bilinear interpolation to reach the exact
+    target size.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of channels in the input feature map.
+    latent_dim : int
+        Desired number of output channels.
+    target_z : int
+        Target height of the BEV map (Z dimension).
+    target_x : int
+        Target width of the BEV map (X dimension).
+    downsample_factor : int, optional
+        Factor by which the backbone downsampled the BEV plane.  Must be a
+        positive integer.  Defaults to 8.
+    """
+
+    def __init__(self,
+                 in_channels: int,
+                 latent_dim: int,
+                 target_z: int,
+                 target_x: int,
+                 downsample_factor: int = 8) -> None:
+        super().__init__()
+
+        if downsample_factor <= 0:
+            raise ValueError(
+                f"downsample_factor must be a positive integer, got {downsample_factor}"
+            )
+
+        self.in_channels = in_channels
+        self.latent_dim = latent_dim
+        self.target_z = target_z
+        self.target_x = target_x
+        self.downsample_factor = downsample_factor
+
+        # Compute the expected coarse feature dimensions produced by VoxelNeXt.
+        # We assume the downsampling is the same along both spatial dimensions.
+        # If the downsampling factors along Z and X differ, adjust this logic
+        # accordingly.
+        self.coarse_z = max(1, target_z // downsample_factor)
+        self.coarse_x = max(1, target_x // downsample_factor)
+
+        # Determine the number of 2x upsampling stages needed to approach
+        # the target resolution.  We keep track of how much upsampling we
+        # perform along each dimension separately.
+        self.upsample_stages_z = int(math.log2(max(1, downsample_factor)))
+        self.upsample_stages_x = int(math.log2(max(1, downsample_factor)))
+
+        # Build upsampling layers.  Each layer upsamples by a factor of 2.
+        # We use stride=2 transposed convolutions with kernel size 3 and
+        # appropriate padding to double the resolution.  InstanceNorm is used
+        # instead of BatchNorm to avoid batch‑size dependencies.
+        layers = []
+        current_channels = in_channels
+        for i in range(max(self.upsample_stages_z, self.upsample_stages_x)):
+            stride_h = 2 if i < self.upsample_stages_z else 1
+            stride_w = 2 if i < self.upsample_stages_x else 1
+            # When stride is 1, kernel_size=1 ensures no spatial change.
+            kernel_size_h = 2 if stride_h > 1 else 1
+            kernel_size_w = 2 if stride_w > 1 else 1
+            padding_h = 0 if stride_h == 1 else 0
+            padding_w = 0 if stride_w == 1 else 0
+            layers.append(
+                nn.Sequential(
+                    nn.ConvTranspose2d(
+                        current_channels,
+                        current_channels,
+                        kernel_size=(kernel_size_h, kernel_size_w),
+                        stride=(stride_h, stride_w),
+                        padding=(padding_h, padding_w),
+                        bias=False,
+                    ),
+                    nn.InstanceNorm2d(current_channels),
+                    nn.ReLU(inplace=True),
+                )
+            )
+        self.upsample_layers = nn.ModuleList(layers)
+
+        # Final projection to latent_dim channels.  If the number of channels
+        # hasn't changed, this becomes an identity.
+        if current_channels != latent_dim:
+            self.proj = nn.Sequential(
+                nn.Conv2d(current_channels, latent_dim, kernel_size=1, bias=False),
+                nn.InstanceNorm2d(latent_dim),
+                nn.ReLU(inplace=True),
+            )
+        else:
+            self.proj = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Upsample a coarse BEV feature map to the target BEV resolution.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape ``(B, C_in, H_in, W_in)``.  Typically, this is
+            the output of the VoxelNeXt backbone where ``H_in`` and ``W_in``
+            correspond to ``target_z // downsample_factor`` and
+            ``target_x // downsample_factor``.
+
+        Returns
+        -------
+        torch.Tensor
+            Upsampled feature map of shape ``(B, latent_dim, target_z, target_x)``.
+        """
+        # Apply the upsampling layers.
+        for layer in self.upsample_layers:
+            x = layer(x)
+
+        # If the output shape does not match the desired resolution exactly,
+        # interpolate to the target size.  This handles cases where the
+        # downsampling factor is not an exact power of two or where the target
+        # dimensions are not divisible by the downsampling factor.
+        if x.shape[2] != self.target_z or x.shape[3] != self.target_x:
+            x = F.interpolate(
+                x, size=(self.target_z, self.target_x), mode="bilinear", align_corners=False
+            )
+
+        # Project to the desired latent dimension.
+        x = self.proj(x)
+        return x

--- a/nets/voxelnet.py
+++ b/nets/voxelnet.py
@@ -35,7 +35,6 @@ class Conv2d(nn.Module):
             return x
 
 
-# conv3d + bn + relu
 class Conv3d(nn.Module):
 
     def __init__(self, in_channels, out_channels, k, s, p, batch_norm=True):

--- a/train.py
+++ b/train.py
@@ -625,7 +625,7 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
 
     lid_occ_mem0 = None
     if use_lidar and lid_xyz_cam0 is not None:
-        if use_lidar_encoder and lidar_encoder_type == 'voxel_net':
+        if use_lidar_encoder and lidar_encoder_type in ['voxel_net', 'voxel_next']:
             # use the intensity you already built from lid_data (trimmed to lid_keep!)
             # shapes: lid_xyz_cam0 -> (B, N, 3), lid_intensity -> (B, N, 1)
             assert lid_xyz_cam0.shape[0] == lid_intensity.shape[0] and lid_xyz_cam0.shape[1] == lid_intensity.shape[1], \

--- a/train.py
+++ b/train.py
@@ -566,7 +566,16 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
         lid_data  = lid_data[:, :lid_keep, :]
 
         xyz_lid       = lid_data[:, :, :3]
-        lid_intensity = lid_data[:, :, 3:4]            # keep if you want intensity in voxel feats
+        lid_intensity = lid_data[:, :, 3:4]  
+
+        # add a branch for voxelnext
+        if lidar_encoder_type == 'voxel_net':
+            lid_feats = lid_intensity          # 1 channel: intensity
+        elif lidar_encoder_type == 'voxel_next':
+            # include intensity and timestamp
+            lid_feats = lid_data[:, :, 3:5]    # (B, V, 2)
+        else:
+            raise ValueError(f"Unsupported lidar encoder: {lidar_encoder_type}")          
     else:
         xyz_lid = None
 
@@ -632,7 +641,7 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device='cuda:0', sw=N
                 f"LIDAR xyz/feat mismatch: {lid_xyz_cam0.shape} vs {lid_intensity.shape}"
 
             lid_vox_feats, lid_vox_coords, lid_num_vox = vox_util.voxelize_xyz_and_feats_voxelnet(
-                lid_xyz_cam0, lid_intensity, Z, Y, X,
+                lid_xyz_cam0, lid_feats, Z, Y, X,
                 assert_cube=False,
                 clean_eps=0.0, 
                 max_voxels=6000)   # e.g., 6k for LiDAR

--- a/train_DDP.py
+++ b/train_DDP.py
@@ -659,7 +659,7 @@ def run_model(model, loss_fn, map_seg_loss_fn, d, Z, Y, X, device, sw=None,
     # --- LiDAR (VoxelNet path, mirrors train.py) ---
     lid_occ_mem0 = None
     if use_lidar and lid_xyz_cam0 is not None:
-        if use_lidar_encoder and lidar_encoder_type == 'voxel_net':
+        if use_lidar_encoder and lidar_encoder_type in ['voxel_net', 'voxel_next']:
             # We already built lid_intensity above as lid_data[:, :, 3:4]
             assert lid_xyz_cam0.shape[0] == lid_intensity.shape[0] and \
                    lid_xyz_cam0.shape[1] == lid_intensity.shape[1], \


### PR DESCRIPTION
## Summary
- add support for selecting the VoxelNeXt sparse LiDAR backbone via configuration
- convert voxelized LiDAR tensors to the sparse format expected by VoxelNeXt and align its BEV output with existing fusion
- update configs and data preparation paths to accept either VoxelNet or VoxelNeXt encoders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692870acec4083228b71cc924b302f0a)